### PR TITLE
Closes #27 - Remove notion of shape tree decorator versioning

### DIFF
--- a/shapetree.ttl
+++ b/shapetree.ttl
@@ -50,14 +50,6 @@
   rdfs:comment "Links a ShapeTree to a ShapeTreeReference"@en ;
   rdfs:label "References"@en .
 
-:matchesUriTemplate
-  a owl:DatatypeProperty ;
-  rdfs:domain :ShapeTree ;
-  rdfs:range xsd:string ;
-  rdfs:comment "Describes a URI Template (RFC 6570) that governs the naming of resources of this Shape Tree"@en ;
-  rdfs:isDefinedBy <> ;
-  rdfs:label "Matches URI Template"@en .
-
 :validatedBy
   a owl:ObjectProperty ;
   rdfs:domain :ShapeTree ;
@@ -193,6 +185,15 @@
   rdfs:isDefinedBy <> ;
   rdfs:label "Has Series"@en .
 
+:defaultLanguage
+  a owl:ObjectProperty ;
+  rdfs:domain :ShapeTreeDecoratorIndex ;
+  rdfs:range xsd:language ;
+  rdfs:comment "Defines default language for use with shape tree decorator when none exist matching user preferences"@en ;
+  rdfs:isDefinedBy <> ;
+  rdfs:label "Default language"@en .
+
+
 # ShapeTreeDecoratorSeries class
 #############################################################################
 # A ShapeTreeDecoratorSeries details a versioned set of ShapeTreeDecoratorHierarchy classes
@@ -208,62 +209,42 @@
 #
 # Properties in domain of ShapeTreeDecoratorSeries
 #
-:hasHierarchy
+:hasShapeTreeDecoratorResource
   a owl:ObjectProperty ;
   rdfs:domain :ShapeTreeDecoratorSeries ;
-  rdfs:range :ShapeTreeDecoratorHierarchy ;
-  rdfs:comment "Links between a ShapeTreeDecoratorSeries and a ShapeTreeDecoratorHierarchy"@en ;
+  rdfs:range :ShapeTreeDecoratorResource ;
+  rdfs:comment "Links between a ShapeTreeDecoratorSeries and the decorator resource itself"@en ;
   rdfs:isDefinedBy <> ;
-  rdfs:label "Has Hierarchy"@en .
+  rdfs:label "Has Decorator Resource"@en .
 
-# ShapeTreeDecoratorHierarchy class
-#############################################################################
-# A ShapeTreeDecoratorHierarchy details a versioned SKOS poly-hierarchy that describes
-# a ShapeTree in a given language or format for an intended audience
-# (decreased cognitivty ability, etc.)
-#############################################################################
-:ShapeTreeDecoratorHierarchy
-  a rdfs:Class ;
-  rdfs:comment "Describes a SKOS poly-hierarchy for purproses of labeling a ShapeTree"@en ;
-  rdfs:isDefinedBy <> ;
-  rdfs:label "ShapeTreeDecoratorHierarchy"@en .
-
-# Properties in domain of ShapeTreeDecoratorHierarchy
-#########################################################
-:hasVersion
-  a owl:DatatypeProperty ;
-  rdfs:domain :ShapeTreeDecoratorHierarchy ;
-  rdfs:range xsd:string ;
-  rdfs:comment "Describes the version of a ShapeTreeDecoratorHierarchy"@en ;
-  rdfs:isDefinedBy <> ;
-  rdfs:label "Has Version"@en .
-
-:hasSHA256Hash
-  a owl:DatatypeProperty ;
-  rdfs:domain :ShapeTreeDecoratorHierarchy ;
-  rdfs:range xsd:string ;
-  rdfs:comment "Describes the SHA-256 of a ShapeTreeDecoratorHierarchy"@en ;
-  rdfs:isDefinedBy <> ;
-  rdfs:label "Has SHA-256 Hash"@en .
-
-:hasSkosGraph
+:usesLanguage
   a owl:ObjectProperty ;
-  rdfs:domain :ShapeTreeDecoratorHierarchy ;
-  rdfs:range :ShapeTreeLabel ;
-  rdfs:comment "Represents the IRI to the SKOS graph described by ShapeTreeDecoratorHierarchy instance"@en ;
+  rdfs:domain :ShapeTreeDecoratorSeries ;
+  rdfs:range xsd:language ;
+  rdfs:comment "Describes the language used by associated ShapeTreeDecoratorResource"@en ;
   rdfs:isDefinedBy <> ;
-  rdfs:label "Has SKOS Graph"@en .
+  rdfs:label "Uses language"@en .
 
-# ShapeTreeLabel class
+# ShapeTreeDecoratorResource class
 #############################################################################
-# A ShapeTreeLabel details the association between a label within a SKOS graph
-# (detailed by ShapeTreeDecoratorHierarchy) and a ShapeTree
+# A ShapeTreeDecoratorResource represents a SKOS-based resource which
+# is made up of multiple st:ShapeTreeDecorator nodes that describe shape trees
 #############################################################################
-:ShapeTreeLabel
+:ShapeTreeDecoratorResource
   a rdfs:Class ;
-  rdfs:comment "Describes the association between a SKOS label and a ShapeTree"@en ;
+  rdfs:comment "Represents a SKOS-based resource which is made up of multiple st:ShapeTreeDecorator nodes that describe shape trees"@en ;
   rdfs:isDefinedBy <> ;
-  rdfs:label "ShapeTreeLabel"@en .
+  rdfs:label "ShapeTreeDecoratorResource"@en .
+
+# ShapeTreeDecorator class
+#############################################################################
+# A ShapeTreeDecorator represents a single descriptor of a shape tree
+#############################################################################
+:ShapeTreeDecorator
+  a rdfs:Class ;
+  rdfs:comment "A ShapeTreeDecorator represents a single descriptor of a shape tree"@en ;
+  rdfs:isDefinedBy <> ;
+  rdfs:label "ShapeTreeDecorator"@en .
 
 
 # Properties in the range of ShapeTreeLocator

--- a/shapetree.ttl
+++ b/shapetree.ttl
@@ -177,13 +177,13 @@
 
 # Properties in domain of ShapeTreeDecoratorIndex
 #########################################################
-:hasSeries
+:hasSet
   a owl:ObjectProperty ;
   rdfs:domain :ShapeTreeDecoratorIndex ;
-  rdfs:range :ShapeTreeDecoratorSeries ;
-  rdfs:comment "Links between a ShapeTreeDecoratorIndex and a ShapeTreeDecoratorSeries"@en ;
+  rdfs:range :ShapeTreeDecoratorSet ;
+  rdfs:comment "Links between a ShapeTreeDecoratorIndex and a ShapeTreeDecoratorSet"@en ;
   rdfs:isDefinedBy <> ;
-  rdfs:label "Has Series"@en .
+  rdfs:label "Has Set"@en .
 
 :defaultLanguage
   a owl:ObjectProperty ;
@@ -194,26 +194,26 @@
   rdfs:label "Default language"@en .
 
 
-# ShapeTreeDecoratorSeries class
+# ShapeTreeDecoratorSet class
 #############################################################################
-# A ShapeTreeDecoratorSeries details a versioned set of ShapeTreeDecoratorHierarchy classes
-# Primary use is grouping TreeDecoratorHierarchy instances by a common discriminator
+# A ShapeTreeDecoratorSet details a set of ShapeTreeDecoratorResource classes
+# Primary use is grouping TreeDecoratorResource instances by a common discriminator
 # such as language or intended audience
 #############################################################################
-:ShapeTreeDecoratorSeries
+:ShapeTreeDecoratorSet
   a rdfs:Class ;
-  rdfs:comment "Groups a set of ShapeTreeDecoratorHierarchy by a given discriminator"@en ;
+  rdfs:comment "Groups a set of ShapeTreeDecoratorResource by a given discriminator"@en ;
   rdfs:isDefinedBy <> ;
-  rdfs:label "ShapeTreeDecoratorSeries"@en .
+  rdfs:label "ShapeTreeDecoratorSet"@en .
 
 #
-# Properties in domain of ShapeTreeDecoratorSeries
+# Properties in domain of ShapeTreeDecoratorSet
 #
 :hasShapeTreeDecoratorResource
   a owl:ObjectProperty ;
-  rdfs:domain :ShapeTreeDecoratorSeries ;
+  rdfs:domain :ShapeTreeDecoratorSet ;
   rdfs:range :ShapeTreeDecoratorResource ;
-  rdfs:comment "Links between a ShapeTreeDecoratorSeries and the decorator resource itself"@en ;
+  rdfs:comment "Links between a ShapeTreeDecoratorSet and the decorator resource itself"@en ;
   rdfs:isDefinedBy <> ;
   rdfs:label "Has Decorator Resource"@en .
 

--- a/spec.bs
+++ b/spec.bs
@@ -1654,18 +1654,18 @@ describe the shape tree in human-readable terms.
 * The { <code>IDX</code> <code>a</code>
     <code class="vocab">st:ShapeTreeDecoratorIndex</code> } [=arc=] indicates a
     <code class="vocab">st:ShapeTreeDecoratorIndex</code> that represents an
-    index of <code class="vocab">st:ShapeTreeDecoratorSeries</code>.
-* The { <code>IDX</code> <code class="vocab">st:hasSeries</code>
-    <code>SERIES</code> } [=arc=] indicates linkage to one or more
-    <code class="vocab">st:ShapeTreeDecoratorSeries</code>.
-* The { <code>SERIES</code> <code>a</code>
-    <code class="vocab">st:ShapeTreeDecoratorSeries</code> } [=arc=] indicates a
-    <code class="vocab">st:ShapeTreeDecoratorSeries</code> that represents a
+    index of <code class="vocab">st:ShapeTreeDecoratorSet</code>.
+* The { <code>IDX</code> <code class="vocab">st:hasSet</code>
+    <code>SET</code> } [=arc=] indicates linkage to one or more
+    <code class="vocab">st:ShapeTreeDecoratorSet</code>.
+* The { <code>SET</code> <code>a</code>
+    <code class="vocab">st:ShapeTreeDecoratorSet</code> } [=arc=] indicates a
+    <code class="vocab">st:ShapeTreeDecoratorSet</code> that represents a
     [=SKOS graphs=] for a given language or interpretation.
-* The { <code>SERIES</code> <code class="vocab">st:hasShapeTreeDecoratorResource</code>
+* The { <code>SET</code> <code class="vocab">st:hasShapeTreeDecoratorResource</code>
     <code>DECRESOURCE</code> } [=arc=] indicates linkage to a single
     <code class="vocab">st:ShapeTreeDecoratorResource</code>.
-* The { <code>SERIES</code> <code class="vocab">st:usesLanguage</code>
+* The { <code>SET</code> <code class="vocab">st:usesLanguage</code>
     <code>LANG</code> } [=arc=] indicates the language used by the associated
     <code>DECRESOURCE</code>.
 
@@ -1680,11 +1680,11 @@ describe the shape tree in human-readable terms.
   &lt;#DecoratorIndex&gt; {
     a [ st:ShapeTreeDecoratorIndex ] ;
     st:defaultLanguage xsd:language ? ;
-    st:hasSeries IRI*
+    st:hasSet IRI*
   }
 
-  &lt;#DecoratorSeries&gt; {
-    a [ st:ShapeTreeDecoratorSeries ] ;
+  &lt;#DecoratorSet&gt; {
+    a [ st:ShapeTreeDecoratorSet ] ;
     st:usesLanguage xsd:language ;
     st:hasShapeTreeDecoratorResource IRI
   }

--- a/spec.bs
+++ b/spec.bs
@@ -188,11 +188,6 @@ For any [=shape tree=] <code>S</code> linked in <code>ST</code>:
 * An { <code>S</code> <code class="vocab">rdfs:label</code> <code>L</code> } [=arc=]
     indicates that there is exactly one corresponding resource <code>R</code>
     and it has the name <code>L</code>.
-* An { <code>S</code> <code class="vocab">st:matchesUriTemplate</code>
-    <code>L</code> } [=arc=] indicates that there <em class="rfc2119">MAY</em>
-    be an arbitrary number of corresponding resources <code>R</code>
-    and each will have a name that matches the URI template
-    [[RFC6570]] <code>L</code>.
 * An { <code>S</code> <code class="vocab">st:validatedBy</code> <code>Sh</code> }
     [=arc=] indicates that <code>R</code> <em class="rfc2119">MUST</em>
     have exactly one node which conforms to [=shape=] <code>Sh</code>.
@@ -223,7 +218,7 @@ A { <code class="vocab">st:hasShapeTreeDecoratorIndex</code> <code>Si</code> }
 	    st:expectsType [st:ShapeTreeContainer] ;
 	    st:contains @&lt;#ShapeTree&gt; +
 	  ) ;
-    (rdfs:label xsd:string | st:matchesUriTemplate xsd:string) ;
+    rdfs:label xsd:string ? ;
 	  st:references @&lt;#ReferencedShapeTree&gt; * ;
 	  st:validatedBy IRI ? ;
     st:contains IRI ? ;
@@ -1665,29 +1660,44 @@ describe the shape tree in human-readable terms.
     <code class="vocab">st:ShapeTreeDecoratorSeries</code>.
 * The { <code>SERIES</code> <code>a</code>
     <code class="vocab">st:ShapeTreeDecoratorSeries</code> } [=arc=] indicates a
-    <code class="vocab">st:ShapeTreeDecoratorSeries</code> that represent a
-    series of versioned [=SKOS graphs=] for a given language or interpretation.
-* The { <code>SERIES</code> <code class="vocab">st:hasHierarchy</code>
-    <code>HIER</code> } [=arc=] indicates linkage to one or more
-    <code class="vocab">st:ShapeTreeDecoratorHierarchy</code>.
-* The { <code>HIER</code> <code>a</code>
-    <code class="vocab">st:ShapeTreeDecoratorHierarchy</code> } [=arc=] indicates
-    a <code class="vocab">st:ShapeTreeDecoratorHierarchy</code> that represent
-    a single versioned [=SKOS graph=].
-    * The { <code>HIER</code> <code class="vocab">st:hasSkosGraph</code>
-        <code>SKOS</code> } [=arc=] indicates that there is exactly one
-        [=SKOS graph=] describing <code>STs</code>
-    * The { <code>HIER</code> <code class="vocab">st:hasVersion</code>
-        <code>VERSION</code> } [=arc=] indicates the version of the [=SKOS graph=]
-        <code>SKOS</code>
-    * The { <code>HIER</code> <code class="vocab">st:hasSHA256</code>
-        <code>HASH</code> } [=arc=] indicates the hash of [=SKOS graph=]
-        <code>SKOS</code>
-* Each { <code>SKOSSUB</code> <code>a</code>
-    <code class="vocab">st:ShapeTreeLabel</code> } in <code>SKOS</code>
-    refers back to the [=shape tree=] <code>ST</code> via the
-    { <code>SKOSSUB</code> <code class="vocab">st:hasShapeTree</code>
-    <code>ST</code> } [=arc=].
+    <code class="vocab">st:ShapeTreeDecoratorSeries</code> that represents a
+    [=SKOS graphs=] for a given language or interpretation.
+* The { <code>SERIES</code> <code class="vocab">st:hasShapeTreeDecoratorResource</code>
+    <code>DECRESOURCE</code> } [=arc=] indicates linkage to a single
+    <code class="vocab">st:ShapeTreeDecoratorResource</code>.
+* The { <code>SERIES</code> <code class="vocab">st:usesLanguage</code>
+    <code>LANG</code> } [=arc=] indicates the language used by the associated
+    <code>DECRESOURCE</code>.
+
+<figure id="shapetree-decorator-shex">
+  <figcaption>ShEx validation of a Shape Tree Decorators</figcaption>
+  <pre highlight="turtle">
+  prefix st: &lt;http://www.w3.org/ns/st#&gt;.
+  prefix rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;.
+  prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt;.
+  prefix skos: &lt;http://www.w3.org/2004/02/skos/core#&gt;.
+
+  &lt;#DecoratorIndex&gt; {
+    a [ st:ShapeTreeDecoratorIndex ] ;
+    st:defaultLanguage xsd:language ? ;
+    st:hasSeries IRI*
+  }
+
+  &lt;#DecoratorSeries&gt; {
+    a [ st:ShapeTreeDecoratorSeries ] ;
+    st:usesLanguage xsd:language ;
+    st:hasShapeTreeDecoratorResource IRI
+  }
+
+  &lt;#Decorator&gt; {
+    a [ st:ShapeTreeDecorator ] ;
+    st:hasShapeTree IRI ;
+    skos:prefLabel xsd:string ;
+    skos:definition xsd:string ?
+  }
+  
+  </pre>
+</figure>    
 
 SKOS constructs such as <code>skos:narrower</code> <em class="rfc2119">MAY</em>
   be used to group or organize related [=shape trees=].


### PR DESCRIPTION
* Update vocabulary which was out of date
* Update spec to reflect updated relationship of ShapeTreeDecoratorIndex -> ShapeTreeDecoratorSeries -> ShapeTreeDecoratorResource
* Add ShEx validation of decorator structure
* Update ShEx schema for Shape tree to remove errant reference to :matchesURITemplate