### PR TITLE
Use document as locator base

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -740,9 +740,7 @@ focus nodes.
   PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;  
   PREFIX ex: &lt;http://www.example/ns/ex#&gt;
 
-  &lt;&gt; st:hasShapeTreeLocator &lt;#locator&gt; .
-
-  &lt;#locator&gt;
+  &lt;&gt;
     a st:ShapeTreeLocator ;
     st:location <#location1>, <#location2> .
     
@@ -772,9 +770,7 @@ focus nodes.
   PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;  
   PREFIX ex: &lt;http://www.example/ns/ex#&gt;
 
-  &lt;&gt; st:hasShapeTreeLocator &lt;#locator&gt; .
-
-  &lt;#locator&gt;
+  &lt;&gt;
     a st:ShapeTreeLocator ;
     st:location <#location1> .
 
@@ -825,9 +821,7 @@ in which case only the focus node and shape are provided, via
   PREFIX ex: &lt;http://www.example/ns/ex#&gt;
   PREFIX project1: &lt;https://storage.example/data/projects/project-1#&gt;
   
-  &lt;&gt; st:hasShapeTreeLocator &lt;#locator&gt; .
-
-  &lt;#locator&gt;
+  &lt;&gt;
     a st:ShapeTreeLocator ;
     st:location <#location1> .
 
@@ -949,7 +943,7 @@ given [=resource=] in a single request.
 
 <pre highlight="http">
   HTTP/1.1 200 OK
-  Link: &lt;https://storage.example/meta/c560224b#locator&gt;; rel="http://www.w3.org/ns/shapetrees#ShapeTreeLocator"
+  Link: &lt;https://storage.example/meta/c560224b&gt;; rel="http://www.w3.org/ns/shapetrees#ShapeTreeLocator"
   Link: &lt;http://www.w3.org/ns/ldp#Container&gt;; rel="type"
   ...other HTTP response headers omitted...
 </pre>
@@ -974,9 +968,7 @@ given [=resource=] in a single request.
   PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;  
   PREFIX ex: &lt;http://www.example/ns/ex#&gt;
 
-  &lt;&gt; st:hasShapeTreeLocator &lt;#locator&gt; .
-
-  &lt;#locator&gt;
+  &lt;&gt;
     a st:ShapeTreeLocator ;
     st:location <#location1> .
     
@@ -1092,7 +1084,7 @@ PREFIX st: &lt;http://www.w3.org/ns/shapetrees#&gt;
 PREFIX rdfs: &lt;http://www.w3.org/2000/01/rdf-schema#&gt;  
 PREFIX ex: &lt;http://www.example/ns/ex#&gt;
 
-&lt;#locator&gt;
+&lt;&gt;
   a st:ShapeTreeLocator ;
   st:location <#location1>, <#location2> .
   
@@ -1838,7 +1830,7 @@ The following algorithms define a library of functions referenced in the above
       <td>`FN`</td>
       <td>
         An <em class="rfc2119">Optional</em> focus node to use for shape 
-        validation when `TST st:shape` is set 
+        validation when `ST st:shape` is set 
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
Update locator examples to use the document URI as the locator base.