### PR TITLE
Feat: added shape tree discrimination through Resource class

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1705,6 +1705,7 @@ The following algorithms define a library of functions referenced in the above
 <div class="opdetails">
 
 1. Return a failing validation result if `ST st:expectedType` is set and is not the resource type of `R`
+1. Return a failing validation result if `ST st:targetClass` is set and is not equal to the class of the resource 'R'
 1. Return a failing validation result if `ST rdfs:label` is set and is not equal to the resource name of `R`
 1. Return a failing validation result if `ST st:shape` is set and shape validation of the body content of `R` fails
 1. Return a positive validation result

--- a/shapetrees.ttl
+++ b/shapetrees.ttl
@@ -53,6 +53,14 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
   rdfs:isDefinedBy <> ;
   rdfs:label "Shape"@en .
 
+:targetClass  
+    a owl:ObjectProperty ;  
+    rdfs:domain :ShapeTree ;  
+    rdfs:range rdfs:Class ;  
+    rdfs:comment "Specifies the class of the managed resource"@en ;  
+    rdfs:isDefinedBy <> ;  
+    rdfs:label "targetClass"@en .  
+
 # Container IRI (maps to ldp:Container)
 #############################################################################
 # An IRI that represents a generalized container used in a ShapeTree


### PR DESCRIPTION
As I explained in [this issue](https://github.com/solid/data-interoperability-panel/issues/277) and [this issue](https://github.com/shapetrees/specification/issues/75), I think that a little addition to shape tree semantics is needed in order to fully distinguish this shape tree
```
<#TaskTree>
  a st:ShapeTree ;
  st:expectsType st:Resource ;
  st:shape pm-shex:TaskShape .
```
from this one
```
<#ProjectTree>
  a st:ShapeTree ;
  st:expectsType st:Resource ;
  st:shape pm-shex:ProjectShape ;
  st:references [
    st:hasShapeTree <#TaskTree> ;
    st:viaPredicate pm:hasTask
  ] .
```